### PR TITLE
Fixed read from url method to use URI.open for ruby upgrade 3 on cloudlogistics

### DIFF
--- a/lib/money/bank/uphold.rb
+++ b/lib/money/bank/uphold.rb
@@ -105,11 +105,11 @@ class Money
       end
 
       def read_from_url
-        open(source_url).read
+        URI.open(source_url).read
       end
 
       def source_url
-        URI.join(UPHOLD_TICKERS_BASE_URL, source)
+        URI.join(UPHOLD_TICKERS_BASE_URL, source).to_s
       end
     end
   end


### PR DESCRIPTION
Using `open(source_url).read` gives following error: `TypeError: no implicit conversion of URI::HTTPS into String`
Also the gem is not updating anymore and hence had to fork the gem and make the changes in code